### PR TITLE
Updated Dockerfile

### DIFF
--- a/overlays/python36/Dockerfile
+++ b/overlays/python36/Dockerfile
@@ -24,7 +24,7 @@ USER root
 # Upgrade NodeJS > 12.0
 RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash -  && \
   yum remove -y nodejs && \
-  yum install -y nodejs mesa-libgl
+  yum install -y nodejs mesa-libGL
 
 # Copying in override assemble/run scripts
 COPY .s2i/bin /tmp/scripts


### PR DESCRIPTION
For some reason the mesa-libGL package is case sensitive. I've updated to `mesa-libGL` and it installs. I get stuck at `COPY .s2i/bin /tmp/scripts` still when trying to run podman. Are you running into this issue as well?

## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [ x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Changing `mesa-libgl` to `mesa-libGL` in python36 Dockerfile 

## Description

